### PR TITLE
Fix for not resolving proxies when building a reference

### DIFF
--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/internal/JSONLoad.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/internal/JSONLoad.java
@@ -44,6 +44,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipselabs.emfjson.EMFJs;
 import org.eclipselabs.emfjson.common.ModelUtil;
 
@@ -306,7 +307,7 @@ public class JSONLoad {
 		EObject proxy = getOrCreateProxyReference(reference, root, node, resource);
 		if (proxy != null && reference.isMany()) {
 			@SuppressWarnings("unchecked")
-			EList<EObject> values = (EList<EObject>) eObject.eGet(reference);
+			InternalEList<EObject> values = (InternalEList<EObject>) eObject.eGet(reference);
 			values.add(proxy);
 		} else if (proxy != null) {
 			eObject.eSet(reference, proxy);


### PR DESCRIPTION
When a reference is loaded from JSON which is a proxy, the reference is being resolved instead of being added as a proxy.  This can cause serious performance issues when the JSON is being loaded from the network.
