### PR TITLE
Jackson2

### DIFF
--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/common/ModelUtil.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/common/ModelUtil.java
@@ -17,7 +17,6 @@ import static org.eclipselabs.emfjson.common.Constants.EJS_ROOT_ANNOTATION;
 import java.util.Collections;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonNode;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAnnotation;
 import org.eclipse.emf.ecore.EAttribute;
@@ -28,6 +27,8 @@ import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.resource.Resource;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * 
@@ -152,8 +153,7 @@ public class ModelUtil {
 			nsMap = Collections.emptyMap();
 		}
 
-		@SuppressWarnings("deprecation")
-		final String value = jsonNode.getValueAsText();
+		final String value = jsonNode.asText();
 
 		if (value.startsWith("#//")) {
 			// is fragment

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/Deserializer.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/Deserializer.java
@@ -16,9 +16,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
@@ -28,6 +25,10 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipselabs.emfjson.common.ModelUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 class Deserializer {
 
@@ -88,7 +89,7 @@ class Deserializer {
 		final EList<EObject> returnList = new BasicEList<EObject>();
 		EObject eObject;
 
-		for (Iterator<JsonNode> it = node.getElements(); it.hasNext();) {
+		for (Iterator<JsonNode> it = node.elements(); it.hasNext();) {
 			JsonNode element = it.next();
 			if (element.isObject()) {
 				eObject = from((ObjectNode) element, rootClass, resource);

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/EAttributeSerializer.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/EAttributeSerializer.java
@@ -17,15 +17,16 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Iterator;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.FeatureMap;
 import org.eclipse.emf.ecore.util.FeatureMapUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * 

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/EAtttributeDeserializer.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/EAtttributeDeserializer.java
@@ -17,14 +17,15 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 class EAtttributeDeserializer {
 	
@@ -44,7 +45,7 @@ class EAtttributeDeserializer {
 		// if the value is not an object then
 		// if the key corresponds to an EAttribute, fill it
 		// if not and the EClass contains a MapEntry, fill it with the key, value.
-		for (Iterator<Entry<String, JsonNode>> it = root.getFields(); it.hasNext();) {
+		for (Iterator<Entry<String, JsonNode>> it = root.fields(); it.hasNext();) {
 			Entry<String, JsonNode> field = it.next();
 	
 			String key = field.getKey();
@@ -56,7 +57,7 @@ class EAtttributeDeserializer {
 			EAttribute attribute = getEAttribute(eClass, key);
 			if (isCandidate(attribute)) {
 				if (value.isArray()) {
-					for (Iterator<JsonNode> itValue = value.getElements(); itValue.hasNext();) {
+					for (Iterator<JsonNode> itValue = value.elements(); itValue.hasNext();) {
 						deSerializeValue(eObject, attribute, itValue.next());
 					}
 				} else {
@@ -74,8 +75,7 @@ class EAtttributeDeserializer {
 	}
 
 	void deSerializeValue(EObject eObject, EAttribute attribute, JsonNode value) {
-		@SuppressWarnings("deprecation")
-		final String stringValue = value.getValueAsText();
+		final String stringValue = value.asText();
 
 		if (stringValue != null && !stringValue.trim().isEmpty()) {
 			Object newValue;

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/EObjectMapper.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/EObjectMapper.java
@@ -25,18 +25,19 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig.Feature;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * 
@@ -141,7 +142,7 @@ public class EObjectMapper {
 
 	public ObjectNode to(EObject eObject, Resource resource, Map<?, ?> options) {
 		ObjectMapper mapper = new ObjectMapper();
-		mapper.configure(Feature.INDENT_OUTPUT, false);
+		mapper.configure(SerializationFeature.INDENT_OUTPUT, false);
 
 		return to(eObject, resource);
 	}
@@ -219,7 +220,7 @@ public class EObjectMapper {
 		configure(OPTION_SERIALIZE_TYPE, serializeTypes);
 		configure(OPTION_SERIALIZE_REF_TYPE, serializeRefTypes);
 		configure(OPTION_SERIALIZE_NAMESPACES, serializeNamespaces);
-		objectMapper.configure(Feature.INDENT_OUTPUT, indent);
+		objectMapper.configure(SerializationFeature.INDENT_OUTPUT, indent);
 	}
 
 	public void configure(String key, Object value) {		

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/EReferenceDeserializer.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/EReferenceDeserializer.java
@@ -17,13 +17,14 @@ import static org.eclipselabs.emfjson.common.ModelUtil.isMapEntry;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.resource.Resource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 class EReferenceDeserializer {
 
@@ -41,7 +42,7 @@ class EReferenceDeserializer {
 		final EClass eClass = eObject.eClass();
 		final ObjectNode root = (ObjectNode) node;
 
-		for (Iterator<Entry<String, JsonNode>> it = root.getFields(); it.hasNext();) {
+		for (Iterator<Entry<String, JsonNode>> it = root.fields(); it.hasNext();) {
 			Entry<String, JsonNode> field = it.next();
 
 			String key = field.getKey();
@@ -65,14 +66,14 @@ class EReferenceDeserializer {
 				@SuppressWarnings("unchecked")
 				EList<EObject> values = (EList<EObject>) eObject.eGet(reference);
 
-				for (Iterator<JsonNode> it = value.getElements(); it.hasNext();) {
+				for (Iterator<JsonNode> it = value.elements(); it.hasNext();) {
 					JsonNode current = it.next();
 					EObject contained = createContainedObject(reference, root, current, resource);
 					if (contained != null) values.add(contained);
 				}
 			} 
-			else if (value.getElements().hasNext()) {
-				JsonNode current = value.getElements().next();
+			else if (value.elements().hasNext()) {
+				JsonNode current = value.elements().next();
 				EObject contained = createContainedObject(reference, root, current, resource);
 				if (contained != null) eObject.eSet(reference, contained);
 			}

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/EReferenceResolver.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/EReferenceResolver.java
@@ -18,14 +18,15 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.InternalEList;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 class EReferenceResolver {
 
@@ -48,7 +49,7 @@ class EReferenceResolver {
 		final EClass eClass = eObject.eClass();
 		final ObjectNode root = (ObjectNode) node;
 
-		for (Iterator<Entry<String, JsonNode>> it = root.getFields(); it.hasNext();) {
+		for (Iterator<Entry<String, JsonNode>> it = root.fields(); it.hasNext();) {
 			Entry<String, JsonNode> field = it.next();
 
 			String key = field.getKey();
@@ -59,7 +60,7 @@ class EReferenceResolver {
 					!reference.isDerived() && !reference.isTransient()) {
 
 				if (value.isArray()) {
-					for (Iterator<JsonNode> itEl = value.getElements(); itEl.hasNext();) {
+					for (Iterator<JsonNode> itEl = value.elements(); itEl.hasNext();) {
 						JsonNode current = itEl.next();
 						createProxyReference(eObject, root, current, reference, resource);
 					}

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/EReferenceSerializer.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/EReferenceSerializer.java
@@ -20,9 +20,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
@@ -30,6 +27,10 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * 

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/JSUtil.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/JSUtil.java
@@ -19,8 +19,6 @@ import java.io.InputStream;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
@@ -30,6 +28,9 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.URIConverter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JSUtil {
 
@@ -100,12 +101,11 @@ public class JSUtil {
 		return null;
 	}
 
-	@SuppressWarnings("deprecation")
 	public static JsonNode findNode(JsonNode node, ResourceSet resourceSet, String fragment, URI objectURI) {
 		if (node.isArray()) {
 			int pos = 0;
 			String idx = fragment;
-			for (Iterator<JsonNode> it = node.getElements(); it.hasNext();) {
+			for (Iterator<JsonNode> it = node.elements(); it.hasNext();) {
 				idx = fragment + pos;
 				JsonNode current = it.next();
 				
@@ -113,7 +113,7 @@ public class JSUtil {
 				if (currentEClass != null) {
 					EAttribute id = currentEClass.getEIDAttribute();
 					if (id != null) {
-						if (objectURI.trimFragment().appendFragment(current.get(id.getName()).getValueAsText()).equals(objectURI)) {
+						if (objectURI.trimFragment().appendFragment(current.get(id.getName()).asText()).equals(objectURI)) {
 							return current;
 						}
 					} else {
@@ -143,7 +143,7 @@ public class JSUtil {
 			if (currentEClass != null) {
 				EAttribute id = currentEClass.getEIDAttribute();
 				if (id != null) {
-					if (objectURI.trimFragment().appendFragment(node.get(id.getName()).getValueAsText()).equals(objectURI)) {
+					if (objectURI.trimFragment().appendFragment(node.get(id.getName()).asText()).equals(objectURI)) {
 						return node;
 					}
 				} else {
@@ -172,7 +172,7 @@ public class JSUtil {
 
 	public static EClass getEClass(JsonNode node, ResourceSet resourceSet) {
 		if (node.has(EJS_TYPE_KEYWORD)) {
-			return (EClass) resourceSet.getEObject(URI.createURI(node.get(EJS_TYPE_KEYWORD).getTextValue()), false);
+			return (EClass) resourceSet.getEObject(URI.createURI(node.get(EJS_TYPE_KEYWORD).textValue()), false);
 		} else {
 			return null;
 		}
@@ -226,7 +226,7 @@ public class JSUtil {
 		String fragment = nodeURI.fragment().startsWith("//") ? nodeURI.fragment().substring(2) : nodeURI.fragment();
 
 		for (JsonNode node: root.findParents(eID.getName())) {
-			String value = node.get(eID.getName()).getTextValue();
+			String value = node.get(eID.getName()).textValue();
 			if (value.equals(fragment)){
 				return node;
 			}

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/MapDeserializer.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/MapDeserializer.java
@@ -13,13 +13,14 @@ package org.eclipselabs.emfjson.map;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 class MapDeserializer {
 
@@ -31,23 +32,22 @@ class MapDeserializer {
 			@SuppressWarnings("unchecked")
 			EList<EObject> values = (EList<EObject>) container.eGet(reference);
 
-			for (Iterator<Entry<String, JsonNode>> it = node.getFields(); it.hasNext();) {
+			for (Iterator<Entry<String, JsonNode>> it = node.fields(); it.hasNext();) {
 				Entry<String, JsonNode> element = it.next();
 				values.add(deSerializeEntry(element.getKey(), element.getValue()));
 			}
 		} else {
-			if (node.getFields().hasNext()) {
-				Entry<String, JsonNode> element = node.getFields().next();
+			if (node.fields().hasNext()) {
+				Entry<String, JsonNode> element = node.fields().next();
 				container.eSet(reference, deSerializeEntry(element.getKey(), element.getValue()));
 			}
 		}
 	}
 
-	@SuppressWarnings("deprecation")
 	EObject deSerializeEntry(String key, JsonNode value) {
 		EObject eObject = EcoreUtil.create(EcorePackage.Literals.ESTRING_TO_STRING_MAP_ENTRY);
 		eObject.eSet(EcorePackage.Literals.ESTRING_TO_STRING_MAP_ENTRY__KEY, key);
-		eObject.eSet(EcorePackage.Literals.ESTRING_TO_STRING_MAP_ENTRY__VALUE, value.getValueAsText());
+		eObject.eSet(EcorePackage.Literals.ESTRING_TO_STRING_MAP_ENTRY__VALUE, value.asText());
 
 		return eObject;
 	}

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/MapSerializer.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/MapSerializer.java
@@ -10,13 +10,14 @@
  *******************************************************************************/
 package org.eclipselabs.emfjson.map;
 
-import org.codehaus.jackson.node.ObjectNode;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipselabs.emfjson.common.ModelUtil;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 class MapSerializer {
 		

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/NamespaceDeserializer.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/NamespaceDeserializer.java
@@ -17,21 +17,20 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ObjectNode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 class NamespaceDeserializer {
 
-	@SuppressWarnings("deprecation")
 	Map<String, String> deSerialize(ObjectNode node) {
 		final Map<String, String> nsMap = new HashMap<String, String>();
 
 		if (node.has(EJS_NS_KEYWORD)) {
 			ObjectNode nsNode = (ObjectNode) node.findPath(EJS_NS_KEYWORD);
 
-			for(Iterator<Entry<String, JsonNode>> it = nsNode.getFields(); it.hasNext();) {
+			for(Iterator<Entry<String, JsonNode>> it = nsNode.fields(); it.hasNext();) {
 				Entry<String, JsonNode> entry = it.next();
-				nsMap.put(entry.getKey(), entry.getValue().getValueAsText());
+				nsMap.put(entry.getKey(), entry.getValue().asText());
 			}
 		}
 

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/NamespaceSerializer.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/NamespaceSerializer.java
@@ -2,9 +2,10 @@ package org.eclipselabs.emfjson.map;
 
 import java.util.Map;
 
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.eclipselabs.emfjson.common.Constants;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 class NamespaceSerializer {
 

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/ProxyFactory.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/ProxyFactory.java
@@ -13,13 +13,14 @@ package org.eclipselabs.emfjson.map;
 import static org.eclipselabs.emfjson.common.Constants.EJS_REF_KEYWORD;
 import static org.eclipselabs.emfjson.common.ModelUtil.getEObjectURI;
 
-import org.codehaus.jackson.JsonNode;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 class ProxyFactory {
 

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/Serializer.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/map/Serializer.java
@@ -15,16 +15,17 @@ import static org.eclipselabs.emfjson.common.Constants.EJS_TYPE_KEYWORD;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * 

--- a/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/streams/JsOutputStream.java
+++ b/bundles/org.eclipselabs.emfjson/src/org/eclipselabs/emfjson/streams/JsOutputStream.java
@@ -15,10 +15,12 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonNode;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.URIConverter;
+import org.eclipse.emf.ecore.resource.URIConverter.Saveable;
 import org.eclipselabs.emfjson.map.EObjectMapper;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * 


### PR DESCRIPTION
Hello Guillaume,

emfjson looks cool - just what I need for something I have in mind! ;) Thanks for your work.

The thing I'd like to integrate emfjson with requires Jackson2, and is (non-OSGi) JavaSE, so I cannot have both.

I've just spent a moment trying to make necessary changes to upgrade from the Jackson v1.6.0 you're currently using to a Jackson 2.2.2 I'd need, and it doesn't seem too hard.. they've just changed some package and API names - easy to adapt, see diff. With this, it compiles (no more red) for me under Jackson2.

But this alone doesn't compile yet of course... as I don't have a Jackson2 in my target platform. Do you know how this could be done? Should one of us raise a request to get Jackson2 into Orbit (which currently only has 1.6.0) ?

Thanks.
