### PR TITLE
Output folder of emfjson.example should be target/

### DIFF
--- a/examples/org.eclipselabs.emfjson.example/.classpath
+++ b/examples/org.eclipselabs.emfjson.example/.classpath
@@ -3,5 +3,5 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target"/>
 </classpath>


### PR DESCRIPTION
I'm getting messy dirty *.class in eGit

The output folder of emfjson.example should probably be target/

instead of bin/ (in accordance with your .gitignore)

This fixes it for me.
