### PR TITLE
Replace dynamic specification of dependencies by static ones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,10 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <maven.compiler.fork>true</maven.compiler.fork>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <emf-version>(2.8.0, 3.0.0]</emf-version>
-        <jackson-version>(2.6.5, 3.0.0]</jackson-version>
-        <emf-common-version>(2.8.0, 3.0.0]</emf-common-version>
-        <emf-codegen-version>(2.8.0, 3.0.0]</emf-codegen-version>
+        <emf-version>2.12.0</emf-version>
+        <jackson-version>2.9.1</jackson-version>
+        <emf-common-version>2.12.0</emf-common-version>
+        <emf-codegen-version>2.11.0</emf-codegen-version>
         <xtext-version>2.11.0</xtext-version>
         <ecore-xtext-version>1.2.0</ecore-xtext-version>
         <ecore-xcore-version>1.3.1</ecore-xcore-version>


### PR DESCRIPTION
Since new version of jackson is coming SNAPSHOT dependencies are downloaded and break projects. By using only static specifications of dependencies we avoid to use SNAPSHOTs.