### PR TITLE
Fix generics with type bounds not getting serialized

### DIFF
--- a/src/main/java/org/emfjson/jackson/databind/type/EcoreTypeFactory.java
+++ b/src/main/java/org/emfjson/jackson/databind/type/EcoreTypeFactory.java
@@ -54,7 +54,7 @@ public class EcoreTypeFactory {
 		}
 
 		EGenericType genericType = type.getFeatureType(feature);
-		EClassifier realType = genericType.getEClassifier();
+		EClassifier realType = genericType.getERawType();
 
 		JavaType javaType;
 		if (realType != null) {

--- a/src/test/java/org/emfjson/jackson/tests/generics/GenericTest.java
+++ b/src/test/java/org/emfjson/jackson/tests/generics/GenericTest.java
@@ -129,4 +129,26 @@ public class GenericTest {
 		assertThat(b.getContainsOne())
 				.isNotNull();
 	}
+
+	@Test
+	public void testSaveOtherContainer() {
+		final JsonNode expected = mapper.createObjectNode()
+				.put("eClass", "http://www.emfjson.org/jackson/generics#//OtherContainer")
+				.put("key", "key-123")
+				.set("content", mapper.createObjectNode()
+						.put("eClass", "http://www.emfjson.org/jackson/generics#//ContentA")
+						.put("payload", "some-value"));
+
+		final OtherContainer<ContentA> container = GenericsFactory.eINSTANCE.createOtherContainer();
+		container.setKey("key-123");
+		final ContentA contentA = GenericsFactory.eINSTANCE.createContentA();
+		contentA.setPayload("some-value");
+		container.setContent(contentA);
+
+		final Resource resource = resourceSet.createResource(URI.createURI("types-generic.json"));
+		resource.getContents().add(container);
+
+		final JsonNode jsonNode = mapper.valueToTree(container);
+		assertThat(jsonNode).isEqualTo(expected);
+	}
 }

--- a/src/test/resources/model/generics.xcore
+++ b/src/test/resources/model/generics.xcore
@@ -32,3 +32,14 @@ class Some {}
 class Any {}
 
 class BaseOne extends Base<Some, Any> {}
+
+class OtherContainer<ContentT extends Content> {
+    String key
+    contains ContentT content
+}
+
+interface Content {}
+
+class ContentA extends Content {
+    String payload
+}


### PR DESCRIPTION
Given an `EGenericType`, the `EClassifier` describing the actual data type to be serialized should be obtained via `.getERawType()` and not via `.getEClassifier()`.

The previous behaviour resulted in some generic features not getting serialized at all, see the added test case for an example; without my change the test case would throw the following exception:
```
org.junit.ComparisonFailure: 
Expected :{"eClass":"http://www.emfjson.org/jackson/generics#//OtherContainer","key":"key-123","content":{"eClass":"http://www.emfjson.org/jackson/generics#//ContentA","payload":"some-value"}}
Actual   :{"eClass":"http://www.emfjson.org/jackson/generics#//OtherContainer","key":"key-123"}
```