### PR TITLE
Fix for multiple root objects in JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 .project
 .classpath
 java-gen
+/bin/

--- a/src/main/java/org/emfjson/jackson/databind/deser/EObjectDeserializer.java
+++ b/src/main/java/org/emfjson/jackson/databind/deser/EObjectDeserializer.java
@@ -163,6 +163,10 @@ public class EObjectDeserializer extends JsonDeserializer<EObject> {
 
 		jp.close();
 		buffer.close();
+		
+		EMFContext.setParent(ctxt, null);
+		EMFContext.setFeature(ctxt, null);
+
 		return object;
 	}
 

--- a/src/main/java/org/emfjson/jackson/databind/deser/ReferenceEntry.java
+++ b/src/main/java/org/emfjson/jackson/databind/deser/ReferenceEntry.java
@@ -61,7 +61,6 @@ public interface ReferenceEntry {
 				target = resource.getEObject(id);
 
 				if (target == null) {
-
 					URI baseURI = resource.getURI().trimFragment();
 					URI uri = handler.resolve(baseURI, URI.createURI(id));
 


### PR DESCRIPTION
When the JSON source has multiple root objects, the
current version had all root objects from the second
one take the wrong type. This is because the current
parent and feature fields were not being reset after
reading each object.

This commit fixes the issue, adding some code at the
end of the reading of each root object.