### PR TITLE
Fix infinite loop when an array is given instead of object

### DIFF
--- a/src/main/java/org/emfjson/jackson/databind/deser/EObjectDeserializer.java
+++ b/src/main/java/org/emfjson/jackson/databind/deser/EObjectDeserializer.java
@@ -65,7 +65,8 @@ public class EObjectDeserializer extends JsonDeserializer<EObject> {
 		}
 
 		TokenBuffer buffer = null;
-		while (jp.nextToken() != JsonToken.END_OBJECT) {
+		JsonToken nextToken = jp.nextToken();
+		while (nextToken != JsonToken.END_OBJECT && nextToken != null) {
 			final String field = jp.getCurrentName();
 			final EObjectProperty property = propertyMap.findProperty(field);
 
@@ -84,6 +85,8 @@ public class EObjectDeserializer extends JsonDeserializer<EObject> {
 				}
 				buffer.copyCurrentStructure(jp);
 			}
+
+			nextToken = jp.nextToken();
 		}
 
 		// handle empty objects

--- a/src/test/java/org/emfjson/jackson/tests/ReferenceTest.java
+++ b/src/test/java/org/emfjson/jackson/tests/ReferenceTest.java
@@ -341,4 +341,13 @@ public class ReferenceTest {
 				.isEqualTo("t6");
 	}
 
+	@Test
+	public void testLoadArrayInsteadOfObject() throws IOException {
+		final Resource resource = resourceSet.getResource(
+			URI.createURI("src/test/resources/tests/array-instead-of-object.json"), true);
+
+		assertThat(resource.getContents())
+			.hasSize(1)
+			.hasOnlyElementsOfType(User.class);
+	}
 }

--- a/src/test/resources/tests/array-instead-of-object.json
+++ b/src/test/resources/tests/array-instead-of-object.json
@@ -1,0 +1,4 @@
+{
+  "eClass": "http://www.emfjson.org/jackson/model#//User",
+  "address": []
+}


### PR DESCRIPTION
If a JSON contained an array instead of an object for a given reference
that expects an object normally, the EObjectDeserializer will hang in an
infinite loop. See the added test for an example.

This fixes the issue.